### PR TITLE
Add --scale-available option to scale up/to commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,18 @@ In the case of the `--force` option has the following effects:
 * Idle state of workers will be ignored
 * uptime/billing hour usage of workers will be ignored
 
-### --dry-run optionn
+### --dry-run option
 
 If `--dry-run` is enabled the process will run through and report what it would potentially do, but no instances will be started, stopped or taken in/out of maintenance.
+
+### --scale-available option
+
+Tells the `scale up` and `scale to` commands to ignore "not enough worker" conditions and just scale up whatever is available.
+
+**Example**: a cluster has 10 total workers, 2 online, 1 in a failed setup state, and 7 offline. By default, if asked to
+`scale to 10` the mo-scaler process will observe that it only has 7 available workers to spin up (i.e., there's no way to
+get to 10 workers,) and exit with a complaint about the cluster not having enough workers available. 
+With the `--scale-available` flag the process will only warn about not having enough workers and spin up the 7 available.
 
 ### Auto-scaling details
 

--- a/manager.py
+++ b/manager.py
@@ -105,22 +105,24 @@ def scale(controller):
 
 @scale.command()
 @click.argument('num_workers', type=int)
+@click.option('--scale-available', is_flag=True, default=False)
 @click.pass_obj
 @handle_exit
 @log_before_after_stats
-def to(controller, num_workers):
+def to(controller, num_workers, scale_available):
 
-    controller.scale_to(num_workers)
+    controller.scale_to(num_workers, scale_available)
 
 
 @scale.command()
 @click.argument('num_workers', type=int, default=1)
+@click.option('--scale-available', is_flag=True, default=False)
 @click.pass_obj
 @handle_exit
 @log_before_after_stats
-def up(controller, num_workers):
+def up(controller, num_workers, scale_available):
 
-    controller.scale('up', num_workers)
+    controller.scale('up', num_workers, scale_available)
 
 
 @scale.command()

--- a/tests/test_opsworks_controller.py
+++ b/tests/test_opsworks_controller.py
@@ -142,7 +142,7 @@ class TestOpsworksController(unittest.TestCase):
 
         with patch.object(self.controller, '_scale_up', autospec=True) as scale_up:
             self.controller.scale_to(9)
-            scale_up.assert_called_once_with(5)
+            scale_up.assert_called_once_with(5, False)
 
         with patch.object(self.controller, '_scale_down', autospec=True) as scale_down:
             self.controller.scale_to(2)
@@ -317,6 +317,7 @@ class TestOpsworksController(unittest.TestCase):
             {'InstanceId': '3', 'Hostname': 'workers3', 'Status': 'stopped'},
             {'InstanceId': '4', 'Hostname': 'workers4', 'Status': 'online'},
             {'InstanceId': '5', 'Hostname': 'workers5', 'Status': 'stopped'},
+            wrap=True
         )
         self.assertRaisesRegexp(
             OpsworksScalingException,
@@ -324,3 +325,10 @@ class TestOpsworksController(unittest.TestCase):
             self.controller._scale_up,
             3
         )
+        self.controller._scale_up(3, scale_available=True)
+        self.assertEqual(
+                [0,0,1,0,1],
+                [x.start.call_count for x in self.controller._instances]
+        )
+
+


### PR DESCRIPTION
By default if a cluster has only 5 available workers
(eg, 2 online / 3 offline) and is asked to scale to 6
the command will fail with a message complaining about
the cluster not having enough workers. The --scale-available
option tells mo-scaler to go ahead and scale up to the
available number of workers.
